### PR TITLE
Add no-pager to mesa to allow easier builds

### DIFF
--- a/mesa-asahi-edge/PKGBUILD
+++ b/mesa-asahi-edge/PKGBUILD
@@ -70,7 +70,7 @@ build() {
     -D android-libbacktrace=disabled
 
   # Print config
-  meson configure build
+  meson configure --no-pager build
 
   ninja -C build
   meson compile -C build


### PR DESCRIPTION
Not sure if there is an automated way to do this with makepkg?

[mesa-git](https://aur.archlinux.org/packages/mesa-git) on AUR also does this, see https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mesa-git#n156