### PR TITLE
Add tiny-dfr package and install it by default for out of the box touch bar support

### DIFF
--- a/asahi-meta/PKGBUILD
+++ b/asahi-meta/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hector Martin <marcan@marcan.st>
 
 pkgname=asahi-meta
-pkgver=4
+pkgver=5
 pkgrel=1
 pkgdesc='Asahi Linux core support meta package'
 url='https://www.asahilinux.org'
@@ -12,7 +12,7 @@ package() {
   # Put depends in package() to avoid unecessary build dependencies
   depends=(
     'linux-asahi' 'uboot-asahi' 'm1n1' 'asahi-scripts' 'asahilinux-keyring' 'asahi-fwextract'
-    'alsa-ucm-conf-asahi' 'asahi-configs'
+    'alsa-ucm-conf-asahi' 'asahi-configs' 'tiny-dfr'
   )
 }
 

--- a/tiny-dfr/PKGBUILD
+++ b/tiny-dfr/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Janne Grunau <j@jannau.net
+
+pkgname=tiny-dfr
+pkgver=0.1.1
+pkgrel=1
+pkgdesc='Apple silicon touch bar input / display daemon'
+arch=('aarch64')
+url=https://github.com/WhatAmISupposedToPutHere/tiny-dfr
+license=('MIT' 'APACHE')
+makedepends=(cargo)
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha512sums=('7e61f1b6dac0e559481a6d2db4d994490593a3417fc9aae130ce768064bbaaa6780b7322356b489d7d28040e1b18302194a06803e2ccfa8e97aa94a69c2a96cb')
+
+prepare() {
+    cd $pkgname-$pkgver
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+    cd $pkgname-$pkgver
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release --all-features
+}
+
+package() {
+    cd $pkgname-$pkgver
+    install -Dm755 target/release/$pkgname "$pkgdir"/usr/bin/$pkgname
+    install -Dm644 share/$pkgname/*.svg -t "$pkgdir/usr/share/$pkgname"
+    install -Dm644 etc/systemd/system/$pkgname.service "$pkgdir/usr/lib/systemd/system/$pkgname.service"
+    install -Dm644 etc/udev/rules.d/99-touchbar-seat.rules "$pkgdir/usr/lib/udev/rules.d/99-touchbar-seat.rules"
+    install -Dm644 etc/udev/rules.d/99-touchbar-tiny-dfr.rules "$pkgdir/usr/lib/udev/rules.d/99-touchbar-tiny-dfr.rules"
+    install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+    install -Dm644 LICENSE.material "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.material
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The systemd service is device activated and conditional on the "apple,j293"
and "apple,j493" device tree compatibles. It will not run on other systems
automatically.