### PR TITLE
Bump `pkgrel` for bankstown

### DIFF
--- a/bankstown/PKGBUILD
+++ b/bankstown/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=bankstown
 pkgver=1.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='a barebones bass enhancer'
 arch=('aarch64')
 url='http://asahilinux.org'


### PR DESCRIPTION
There [is the AUR](https://aur.archlinux.org/packages/bankstown) which is on v1.1.0-2 which always gives me the log
```
:: Searching AUR for updates...
 -> bankstown: ignoring package upgrade (1.1.0-1 => 1.1.0-2)
...
```

in yay (I put it in pacman ignore, otherwise it would try to update all the time).

I am bumping pkgrel so yay does not try to upgrade to the AUR one anymore.