### PR TITLE
Add `rust-toolchain.toml`

### DIFF
--- a/mesa-asahi/rust-toolchain.toml
+++ b/mesa-asahi/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustc", "cargo", "rust-src"]
+targets = ["aarch64-unknown-linux-gnu"]

--- a/speakersafetyd/rust-toolchain.toml
+++ b/speakersafetyd/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustc", "cargo", "rust-src"]
+targets = ["aarch64-unknown-linux-gnu"]

--- a/tiny-dfr/rust-toolchain.toml
+++ b/tiny-dfr/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustc", "cargo", "rust-src"]
+targets = ["aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
I think that is a good idea(?) to nail down the used rustc version everyhwere.