### PR TITLE
asahi-desktop-meta should not depend on asahi-calamares-configs / calamares

### DIFF
--- a/asahi-desktop-meta/PKGBUILD
+++ b/asahi-desktop-meta/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=asahi-desktop-meta
 pkgver=4
-pkgrel=1
+pkgrel=2
 pkgdesc='Asahi Linux Plasma support meta package'
 url='https://www.asahilinux.org'
 arch=('any')
@@ -12,7 +12,7 @@ install=asahi-desktop-meta.install
 
 package() {
   # Put depends in package() to avoid unecessary build dependencies
-  depends=(bluedevil bluez-utils bluez-tools pipewire pipewire-audio pipewire-pulse pipewire-alsa wireplumber asahi-audio bankstown speakersafetyd "mesa-asahi>=25.0.0_pre20241211-1" widevine calamares asahi-calamares-configs)
+  depends=(bluedevil bluez-utils bluez-tools pipewire pipewire-audio pipewire-pulse pipewire-alsa wireplumber asahi-audio bankstown speakersafetyd "mesa-asahi>=25.0.0_pre20241211-1" widevine)
 }
 
 # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Both packages are only needed for setup. Afterwards one could simply delete them.
So they come with the installer package but not needed afterwards.
I for example removed both packages from my system, no problem. However if they are required by `asahi-desktop-meta` that would be not possible then.

Also the last state, before we transfered this repo (https://github.com/asahi-alarm/PKGBUILDs/tree/bb0afd19058730b63ece9ae3199cc6c8afbe80a1) `asahi-desktop-meta` did not depend on those packages.