### PR TITLE
Fix provides in mesa-asahi

### DIFF
--- a/mesa-asahi/PKGBUILD
+++ b/mesa-asahi/PKGBUILD
@@ -127,8 +127,9 @@ _install() {
 }
 
 package_mesa-asahi() {
-  provides=('mesa-libgl' 'opengl-driver' 'mesa' 'mesa-asahi' 'vulkan-asahi' 'vulkan-driver' 'opencl-driver' 'opencl-rusticl-mesa')
+  provides=('mesa-libgl' 'opengl-driver' 'mesa' 'vulkan-asahi' 'vulkan-driver' 'opencl-driver' 'opencl-rusticl-mesa')
   conflicts=('mesa-libgl' 'mesa' 'mesa-asahi-edge' 'vulkan-swrast')
+  replaces=('mesa-asahi-edge')
 
   if [[ "$CARCH" == "x86_64" ]]; then
     return 0


### PR DESCRIPTION
The package should not provide its own and the mesa-asahi package should provide the old mesa-asahi-edge package.