### PR TITLE
Fix asahi-bless

### DIFF
--- a/asahi-bless/PKGBUILD
+++ b/asahi-bless/PKGBUILD
@@ -8,7 +8,6 @@ pkgdesc='Tool to select active boot partition on ARM Macs'
 arch=('aarch64')
 url="https://crates.io/crates/$pkgname"
 depends=('rust' 'cargo')
-makedepends=('rust' 'cargo')
 license=('MIT')
 source=(
   "asahi-bless-${pkgver}.tar.gz::https://crates.io/api/v1/crates/asahi-bless/0.4.1/download"
@@ -23,4 +22,5 @@ build() {
 package() {
   cd "${srcdir}/$pkgname-${pkgver}"
   cargo install --locked --path . --root "$pkgdir/usr"
+  rm "$pkgdir/usr/".crates*
 }


### PR DESCRIPTION
* No need to repeat depends in makedepends
* Delete /usr/.crates.toml and /usr/.crates2.json

    The official packages all seems to use manual installation and avoids this issue.