### PR TITLE
feat: adding possibility to target different fedora versions

### DIFF
--- a/check-version.sh
+++ b/check-version.sh
@@ -56,9 +56,7 @@ for P in $PKGS; do
   fi
 
   F=$(curl -s "https://bodhi.fedoraproject.org/updates/?search=$B&status=stable&releases=$REPO" | jq -r '[ first(.updates[] | { nvr: .builds.[].nvr } | select(.nvr | contains("'$B'"))) ]' | jq -r '.[].nvr' | sed "s/$B-\([0-9].*\)/\1/" | sed 's/.[^.]*$//')
-  if [[ -n $F ]]; then
-    F=$(echo $F | sed "s/$B-\([0-9].*\)/\1/")
-  else
+  if [[ -z $F ]]; then
     F="/"
   fi
   printf "%-30s %-30s %-30s\n" "$O" "$F" "$V"

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 declare -A mappings
+declare -A mappings_fedora_repo
 
-mappings["bankstown"]="lv2-bankstown"
+mappings_fedora_repo["bankstown"]="EPEL-10.0"
+mappings_fedora_repo["alsa-ucm-conf-asahi"]="EPEL-10.0"
+
+mappings["bankstown"]="rust-bankstown-lv2"
 mappings["widevine"]="widevine-installer"
 mappings["lzfse"]="lzfse-libs"
 mappings["FEX-Emu"]="fex-emu"
@@ -11,12 +15,18 @@ mappings["linux-asahi"]="kernel-16k"
 mappings["linux-asahi-headers"]="kernel-headers"
 mappings["mesa"]="mesa-vulkan-drivers"
 mappings["alsa-ucm-conf-asahi"]="alsa-ucm-asahi"
-mappings["tiny-dfr"]="rust-tiny-dfr"
-mappings["binfmt-dispatcher"]="rust-binfmt-dispatcher"
-mappings["muvm"]="rust-muvm"
 mappings["asahi-bless"]="rust-asahi-bless"
+mappings["asahi-scripts"]="asahi-scripts"
+mappings["binfmt-dispatcher"]="rust-binfmt-dispatcher"
+mappings["calamares"]="calamares"
+mappings["libkrun"]="libkrun"
+mappings["libkrunfw"]="libkrunfw"
+mappings["tiny-dfr"]="rust-tiny-dfr"
 mappings["triforce-lv2"]="rust-triforce-lv2"
+mappings["virglrenderer"]="virglrenderer"
+mappings["muvm"]="rust-muvm"
 mappings["speakersafetyd"]="rust-speakersafetyd"
+mappings["alsa-ucm-conf-asahi"]="alsa-ucm-asahi"
 
 DB=asahi-alarm.db.tar.gz
 
@@ -34,10 +44,18 @@ for P in $PKGS; do
     continue
   fi
   O=$B
+
+  if [[ -n "${mappings_fedora_repo[$B]}" ]]; then
+    REPO=${mappings_fedora_repo[$B]}
+  else
+    REPO="F41"
+  fi
+
   if [[ -n "${mappings[$B]}" ]]; then
     B=${mappings[$B]}
   fi
-  F=$(curl -s "https://bodhi.fedoraproject.org/updates/?search=$B&status=stable&releases=F41" | jq -r '[ first(.updates.[] | select(.status | contains("stable"))) | { nvr: .builds.[].nvr } ]' | jq -r '.[] | select(.nvr | contains ("'$B'"))' | jq -r '.nvr')
+
+  F=$(curl -s "https://bodhi.fedoraproject.org/updates/?search=$B&status=stable&releases=$REPO" | jq -r '[ first(.updates[] | { nvr: .builds.[].nvr } | select(.nvr | contains("'$B'"))) ]' | jq -r '.[].nvr' | sed "s/$B-\([0-9].*\)/\1/" | sed 's/.[^.]*$//')
   if [[ -n $F ]]; then
     F=$(echo $F | sed "s/$B-\([0-9].*\)/\1/")
   else


### PR DESCRIPTION
Just adding the possiblity to target specific versions for a package and cleaned up the curl command a bit.

---------
Still missing are the following packages:

- linux-asahi ( https://copr.fedorainfracloud.org/coprs/g/asahi/kernel/ )
- linux-asahi-headers ( https://copr.fedorainfracloud.org/coprs/g/asahi/kernel/ )
- virglrenderer
- mesa ( https://copr.fedorainfracloud.org/coprs/g/asahi/mesa/ )
- lzfse 
- steam ( https://copr.fedorainfracloud.org/coprs/g/asahi/steam/ )

