### PR TITLE
Install unstripped VDSO in linux-asahi-headers

### DIFF
--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -151,6 +151,9 @@ _package-headers() {
   echo "Installing KConfig files..."
   find . -name 'Kconfig*' -exec install -Dm644 {} "$builddir/{}" \;
 
+  echo "Installing unstripped VDSO..."
+  make O="$O" INSTALL_MOD_PATH="$pkgdir/usr" vdso_install link=
+
   echo "Removing unneeded architectures..."
   local arch
   for arch in "$builddir"/arch/*/; do


### PR DESCRIPTION
This is needed, for example, to build [zfs-dkms](https://aur.archlinux.org/packages/zfs-dkms) successfully. These are included in the main arch linux package ([ref](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/6.15.1.arch1-1/PKGBUILD?ref_type=tags#L185)).