### PR TITLE
asahi-fwextract: Bump for python 3.14

### DIFF
--- a/asahi-fwextract/PKGBUILD
+++ b/asahi-fwextract/PKGBUILD
@@ -4,7 +4,7 @@
 _name=asahi-alarm-installer
 pkgname=asahi-fwextract
 pkgver=0.7.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Asahi Linux firmware extractor'
 arch=('any')
 url='http://asahilinux.org'


### PR DESCRIPTION
Fixes asahi-alarm/asahi-alarm#26.

0.7.9-1 was built against python 3.13, so `asahi_firmware` sits in
`/usr/lib/python3.13/site-packages` and `asahi-fwextract` fails under the current
python 3.14:

```
$ asahi-fwextract --help
Traceback (most recent call last):
  File "/usr/bin/asahi-fwextract", line 5, in <module>
    from asahi_firmware.update import main
ModuleNotFoundError: No module named 'asahi_firmware'
```

`asahi-fwupdate` calls it by bare name, so re-extracting vendor firmware from
macOS is broken. The `pkgrel` bump is so users actually receive the rebuild
rather than keeping the 0.7.9-1 they have.

Built locally to check (`arch=any`, so an x86_64 host reproduces it) — the module
lands in `usr/lib/python3.14/site-packages/asahi_firmware/` and the package comes
out as 0.7.9-2. The commit touches only `asahi-fwextract/PKGBUILD`, so
`build.yml` picks the package up from `git show --name-only HEAD` without needing
the `packages` input.

Two things left out deliberately, both yours to call:

- This is the third time the same break has shipped (python 3.11, then 3.13,
  now 3.14), because nothing ties the built wheel to the interpreter while
  `depends` carries a bare `python`. I have a patch that appends the
  built-against range to `depends` in `package()` so pacman flags it at upgrade
  time — the catch is that a `python<3.15` bound will block `pacman -Syu` until
  this package is rebuilt, which may well not be a trade you want. Say the word
  and I'll add it here.
- `asahi-alarm-installer` is at v0.8.4 upstream while this stays on 0.7.9.
  `asahi_firmware` still exists at that tag, so a `pkgver` bump would trigger
  the rebuild too if you'd rather ship the newer extractor.
