### PR TITLE
asahi-btsync: update to 0.2.6

### DIFF
--- a/asahi-btsync/PKGBUILD
+++ b/asahi-btsync/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Matthias Kurz <m.kurz@irregular.at>
 
 pkgname=asahi-btsync
-pkgver=0.2.4
+pkgver=0.2.6
 pkgrel=1
 pkgdesc='Tool to sync Bluetooth pairing keys with macos on ARM Macs'
 arch=('aarch64')
@@ -12,7 +12,7 @@ license=('MIT')
 source=(
   "${pkgname}-${pkgver}.tar.gz::https://crates.io/api/v1/crates/${pkgname}/${pkgver}/download"
 )
-sha256sums=('10b44fcd6f66e9dcc7c7315392232619a46cb4467ca9450b2b15bc384ffc722b')
+sha256sums=('3a967ee15e338cb653250a42c6a57c1d424397a03cccda725ab1dcb6de28aa51')
 install=${pkgname}.install
 
 build() {


### PR DESCRIPTION
## Summary

- update `asahi-btsync` from 0.2.4 to 0.2.6
- use the crates.io checksum for the current non-yanked release

Version 0.2.5 fixed the `VariableNotFound` panic when macOS has no
`BluetoothUHEDevices` NVRAM record. This machine still receives 0.2.4-1 from
`asahi-alarm`, so `asahi-btsync.service` fails on every boot even though the
source fix is already published.

Upstream fix: https://github.com/AsahiLinux/asahi-nvram/commit/5986b7891ca30311d946e91ed382d6d5758a12aa

## Verification

- `makepkg --force --verifysource --noconfirm`
- clean non-privileged `makepkg` build on AArch64
- package metadata reports `asahi-btsync 0.2.6-1` and architecture `aarch64`
- packaged binary reports `asahi-btsync 0.2.6`
- package contains the binary, unchanged systemd service and udev rule, and licenses
- `git diff --check origin/main..HEAD`

The built package was also independently QAed on an M2 MacBook Air running
Arch Linux ARM.
