### PR TITLE
fix: fetch asahi-btsync from static.crates.io

### DIFF
--- a/asahi-btsync/PKGBUILD
+++ b/asahi-btsync/PKGBUILD
@@ -10,7 +10,7 @@ url="https://crates.io/crates/$pkgname"
 makedepends=('rustup' 'cargo-license')
 license=('MIT')
 source=(
-  "${pkgname}-${pkgver}.tar.gz::https://crates.io/api/v1/crates/${pkgname}/${pkgver}/download"
+  "${pkgname}-${pkgver}.tar.gz::https://static.crates.io/crates/${pkgname}/${pkgname}-${pkgver}.crate"
 )
 sha256sums=('3a967ee15e338cb653250a42c6a57c1d424397a03cccda725ab1dcb6de28aa51')
 install=${pkgname}.install


### PR DESCRIPTION
The asahi-btsync 0.2.6 update merged in #91 cannot download its source. The crates.io API URL returns HTTP 403 in the [reported CI job](https://github.com/asahi-alarm/PKGBUILDs/actions/runs/33047403446/job/98434589614) and a fresh local makepkg source check. The repository still publishes 0.2.4-1.

This changes only the source URL to the official static.crates.io artifact. It matches the existing SHA-256, `3a967ee15e338cb653250a42c6a57c1d424397a03cccda725ab1dcb6de28aa51`, and the crates.io registry checksum. Package version, release, source contents, service, udev rule, and install script remain unchanged. The [existing investigation](https://github.com/asahi-alarm/PKGBUILDs/pull/91#issuecomment-5476648910) has the failure and workflow details.

Validation:

- Fresh `makepkg --verifysource --noconfirm` passes with the new URL.
- Complete native AArch64 package build passes on an M2 MacBook Air. It used system Rust 1.98.0 and a signature-verified cargo-license binary extracted into a staging directory, with `--nodeps`. This was not a clean chroot build.
- Independent QA passed source integrity, package architecture/version, exact file inventory, unchanged integration files, and unchanged Cargo.lock.
- Isolated synthetic `list` fixtures reproduce VariableNotFound with 0.2.4 and succeed with 0.2.6. A populated synthetic Bluetooth record parses correctly. The sandbox exposes no real NVRAM, pairing files, system bus, or network.
- The local 0.2.6-1 package was installed on the target M2 MacBook Air. A fresh manual service execution on August 31 at 13:46:14 CEST completed with `Result=success` and `ExecMainStatus=0`. This verifies one service execution on the target device; it does not establish cross-OS pairing transfer or next-boot acceptance.

The package still needs a normal clean CI build, signing, and repository publication. Please build `asahi-btsync` explicitly; the later successful jobs following #91 built only asahi-fwextract.
