### PR TITLE
linux-asahi: enable CONFIG_BPF_LSM and add bpf to default LSM list

### DIFF
--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -5,7 +5,7 @@
 _rcver=7.1.13
 #_rcrel=3
 _asahirel=2
-pkgrel=1
+pkgrel=2
 
 _m1n1_version=1.6.1
 
@@ -29,9 +29,9 @@ source=(
   config         # the main kernel config file
 )
 sha256sums=('bcdc3d65e107877eb0fa9679ec682035ed33dcaf679d5a7349bba614588ebedd'
-            '2144ccd26ee42faf84eb3cc697ba83bc130ef86d3f87bfcf414c753b8eb10a44')
+            'd8150a5f501196fd04a6668db4009eaf8549aac3004ae7ad59598fa9340a915d')
 b2sums=('9030c119cd7fc4339b6441430c7ee8417c00b036067135dff427b3fbb2732fb793cd10e5510143f581731a54f9da4611ed014c79b33ad21aed0fbf7bbe9d68a0'
-        'ad95de214deb086584da536484fa486e77a9252ad9b4a870c9de677090d0f685bd753a948fdd94be713806cf59c0cff68eeac6ba1eb260c21d392dbc92fe1178')
+        '3706a4d9c4345ea821a03fd3231423c6f87ff7b94ad8c57a911e888785c52cc77feb97430e3c09c7ed0eb530d3954c724a05b6324e8705f0a2b323a0090c929a')
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase
 export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"

--- a/linux-asahi/config
+++ b/linux-asahi/config
@@ -116,7 +116,7 @@ CONFIG_BPF_JIT=y
 CONFIG_BPF_JIT_DEFAULT_ON=y
 # CONFIG_BPF_UNPRIV_DEFAULT_OFF is not set
 # CONFIG_BPF_PRELOAD is not set
-# CONFIG_BPF_LSM is not set
+CONFIG_BPF_LSM=y
 # end of BPF subsystem
 
 CONFIG_PREEMPT_BUILD=y
@@ -8501,7 +8501,7 @@ CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_IMA_SECURE_AND_OR_TRUSTED_BOOT is not set
 # CONFIG_DEFAULT_SECURITY_APPARMOR is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
+CONFIG_LSM="landlock,yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor,bpf"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
### Summary
This PR enables `CONFIG_BPF_LSM=y` and appends `bpf` to `CONFIG_LSM` in `linux-asahi`.

### Why / Use Case
eBPF-based security tooling and host-level enforcement daemons (such as Cilium Tetragon, Moat, and modern systemd LSM integrations) rely on BPF LSM hooks to enforce policies in-kernel (e.g. blocking unauthorized execution from temp dirs, credential file access, or privilege escalations via `Override` / `-EPERM`).

Right now on `asahi-alarm`, these tools can only fall back to kprobes on `security_*` functions for passive detection, because kprobes cannot override non-error-injectable functions to refuse actions in-kernel.

### Context / Parity
- **Fedora Asahi Remix**: Already enables `CONFIG_BPF_LSM=y` and includes `bpf` in `CONFIG_LSM` (as seen in `linux-asahi/fedora-specs/kernel-aarch64-16k-fedora.config`).
- **Arch Linux (x86_64)**: Has enabled `CONFIG_BPF_LSM=y` and stacked `bpf` in `CONFIG_LSM` for several years.
- **Hardware/Arch support**: All arm64 prerequisites (`CONFIG_HAVE_BPF_TRAMPOLINE`, `CONFIG_BPF_EVENTS`, `CONFIG_DEBUG_INFO_BTF`, `CONFIG_BPF_JIT`) are already active and stable on the 7.1 kernel.

The config just inherited `# CONFIG_BPF_LSM is not set` from the initial 5.16 import before arm64 had BPF trampolines, and `make olddefconfig` has kept the `N` default across kernel bumps since.

### Changes
- `linux-asahi/config`: Set `CONFIG_BPF_LSM=y` and append `,bpf` to `CONFIG_LSM`.
- `linux-asahi/PKGBUILD`: Bump `pkgrel` and update checksums for `config`.